### PR TITLE
Get more info about Kubernetes services

### DIFF
--- a/suse_caasp
+++ b/suse_caasp
@@ -256,6 +256,13 @@ if validate_rpm kubernetes-client && [ -e /usr/bin/kubectl ]; then
     rm ${KUBECTL_LOG} -fr
     find_and_pconf_files /etc/kubernetes -type f
 fi
+
+for K8S_SERVICE in kube-apiserver kube-scheduler kube-controller-manager kube-proxy kubelet; do
+    if validate_rpm $K8S_SERVICE; then
+        plugin_command "systemctl status $K8S_SERVICE"
+        plugin_command "journalctl -u $K8S_SERVICE"
+    fi
+done
 plugin_message Done
 
 #############################################################


### PR DESCRIPTION
Get info about Kubernetes services from Worker nodes for following services:
 * kube-apiserver
 * kube-scheduler
 * kube-controller-manager
 * kube-proxy
 * kubelet

If specific package is installed, plugin will check if service is running and get system logs for it. Following additional commands will be run:
 - systemctl status <SERVICE_NAME>
 - journalctl -u <SERVICE_NAME>