### PR TITLE
Export paths to etcd client certificates, bsc#1046818

### DIFF
--- a/suse_caasp
+++ b/suse_caasp
@@ -350,6 +350,9 @@ section_header "Checking etcd service ..."
 OF=etcd.txt
 plugin_message "All data stored in $OF"
 
+set -a
+[ -f /etc/sysconfig/etcdctl ] && source /etc/sysconfig/etcdctl
+set +a
 if check_rpm etcd && [ -e /usr/bin/etcdctl ]; then
     rpm_verify $OF etcd
     log_cmd $OF 'etcdctl --version'


### PR DESCRIPTION
Command etcdctl uses TLS certificates. To execute this command properly,
 we have to export variables from /etc/sysconfig/etcdctl file.
Before sourcing this file  -a shell option has to be changed,
which makes possible to export all variables.