### PR TITLE
[1.0] Gather the Salt Minion's grains file

### DIFF
--- a/suse_caasp
+++ b/suse_caasp
@@ -406,6 +406,7 @@ if check_rpm salt-minion && [ -e /usr/bin/salt-minion ]; then
     log_cmd $OF 'systemctl status salt-minion'
     log_cmd $OF 'journalctl -u salt-minion'
     conf_files $OF /etc/salt/minion
+    conf_files $OF /etc/salt/grains
     find_and_conf_files $OF /etc/salt/minion.d
     find_and_log_files $OF /var/log/salt
 fi


### PR DESCRIPTION
The grains file provides some useful information, for example the roles
assigned to a minion, and several CaaSP specific state flags

(cherry picked from commit 5a7c616a84c2784c2e7e0a0c66aaf6076f31a01b)

backport of https://github.com/kubic-project/supportutils-plugin-suse-caasp/pull/15