### PR TITLE
when container is not running, no logs are collected

### DIFF
--- a/suse_caasp
+++ b/suse_caasp
@@ -263,7 +263,7 @@ docker_exec() {
         CONTAINERNAME=$2
         shift; shift;
         COMMAND="$@"
-        CONTAINER=$(docker ps | grep $CONTAINERNAME | awk '{print $1}')
+        CONTAINER=$(docker ps -a | grep $CONTAINERNAME | awk '{print $1}')
 
         echo "#==[ $COMMAND ]==" >> $LOGFILE
         docker exec $CONTAINER $COMMAND >> $LOGFILE 2>&1
@@ -465,6 +465,6 @@ if check_rpm docker_1_12_6 && [ -e /usr/bin/docker ] && on_admin; then
     OF=salt-master.txt
     plugin_message "All data stored in $OF"
 
-    docker_exec $OF salt-master salt-key
+    docker_exec $OF salt-master_velum salt-key
     plugin_message Done
 fi


### PR DESCRIPTION
logs should be collected from stopped containers as well

salt-master filter needs to be adapted, as it also would match the
salt-master-config container

Signed-off-by: Maximilian Meister <mmeister@suse.de>