### PR TITLE
[3.0] Fix salt events file names

### DIFF
--- a/suse_caasp
+++ b/suse_caasp
@@ -439,8 +439,8 @@ if check_rpm $DOCKER_PKG && on_admin; then
 
     #############################################################
     section_header "Getting salt events ..."
-    OF=velum-salt-events.yml
-    OFS=velum-salt-events-summary.txt
+    OF=salt-events.json
+    OFS=salt-events-summary.txt
     plugin_message "JSON stored in $OF - Summary stored in $OFS"
 
     /var/lib/supportutils-plugin-suse-caasp/debug-salt --json_output=$OF --summary_output=$OFS --text-status --no-color


### PR DESCRIPTION
Raw salt events are now in JSON format, so we should use .json instead
of .yml. Additionally, these are no longer fetched via Velum - we should
remove velum from the filename.

Backport of https://github.com/kubic-project/supportutils-plugin-suse-caasp/pull/33