### PR TITLE
Add `-o wide` flag to kubectl get commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,15 @@ crictl inspect
 
 Output from commands
 ```
-kubectl config view
 kubectl version
 kubectl api-versions
+kubectl config view
+kubectl get pods -n kube-system -o wide
+kubectl get events --sort-by=.metadata.creationTimestamp
+kubectl get nodes -o wide
+kubectl get all -A -o wide
+kubectl get nodes -o yaml
 kubectl cluster-info dump --all-namespaces --output-directory=/var/log/kubernetes
-kubectl get nodes
-kubectl get nodes
 for srv in kube-proxy kubelet; do
     systemctl status --full $srv
 done

--- a/suse_caasp
+++ b/suse_caasp
@@ -226,10 +226,10 @@ if check_rpm kubernetes-client && [ -f /etc/kubernetes/admin.conf ]; then
     log_cmd $OF 'kubectl version'
     log_cmd $OF 'kubectl api-versions'
     log_cmd $OF 'kubectl config view'
-    log_cmd $OF 'kubectl -n kube-system get pods'
+    log_cmd $OF 'kubectl get pods -n kube-system -o wide'
     log_cmd $OF 'kubectl get events --sort-by=.metadata.creationTimestamp'
-    log_cmd $OF 'kubectl get nodes'
-    log_cmd $OF 'kubectl get all -A'
+    log_cmd $OF 'kubectl get nodes -o wide'
+    log_cmd $OF 'kubectl get all -A -o wide'
     log_cmd $OF 'kubectl get nodes -o yaml'
     set +a
 fi


### PR DESCRIPTION
This lack of information is frustrating when troubleshooting from supportconfigs. Adding this will same some time hunting things down.