### PR TITLE
Show cri-o pods

### DIFF
--- a/suse_caasp
+++ b/suse_caasp
@@ -336,6 +336,7 @@ if check_rpm cri-o && [ -e /usr/bin/crictl ] && [ -S /var/run/crio/crio.sock ]; 
     log_cmd $OF 'crictl images'
     log_cmd $OF 'crictl ps --all'
     log_cmd $OF 'crictl stats --all'
+    log_cmd $OF 'crictl pods'
     conf_files $OF /etc/crictl.yaml
     conf_files $OF /etc/sysconfig/crio
     conf_files $OF /etc/crio/crio.conf


### PR DESCRIPTION
Adds a command to the crio.txt. Adds the output of the command "crictl
pods". I believe it's helpful and quicker to check which pods are
running in the host.

Signed-off-by: José Guilherme Vanz <jguilhermevanz@suse.com>