### PR TITLE
timeout of 3 minutes to get the cluster info

### DIFF
--- a/suse_caasp
+++ b/suse_caasp
@@ -259,7 +259,7 @@ if check_rpm kubernetes-client && [ -f /etc/kubernetes/admin.conf ]; then
     set -a
     export KUBECONFIG=/etc/kubernetes/admin.conf
     if kubectl -n kube-system cluster-info dump &>/dev/null; then
-        timeout 3 kubectl cluster-info dump --output-directory=$KUBECTL_LOG; echo
+        timeout 3m kubectl cluster-info dump --output-directory=$KUBECTL_LOG; echo
         find_and_log_files $OF $KUBECTL_LOG
         rm ${KUBECTL_LOG} -fr
     fi


### PR DESCRIPTION
The kubectl cluster-info dump command takes some time to finish. It
dumps a lot of nice information. The suse_caasp script is setting 3
seconds to the command to finish. This commit increases to 3 minutes.

Signed-off-by: José Guilherme Vanz <jguilhermevanz@suse.com>